### PR TITLE
Kafka 1.1.0

### DIFF
--- a/kafka/Dockerfile
+++ b/kafka/Dockerfile
@@ -1,7 +1,7 @@
 # The only assumption we make about this FROM is that it has a JRE in path
 FROM solsson/kafka-jre@sha256:06dabfc8cacd0687c8f52c52afd650444fb6d4a8e0b85f68557e6e7a5c71667c
 
-ENV KAFKA_VERSION=1.0.1 SCALA_VERSION=2.11
+ENV KAFKA_VERSION=1.1.0 SCALA_VERSION=2.11
 
 RUN set -ex; \
   export DEBIAN_FRONTEND=noninteractive; \


### PR DESCRIPTION
`solsson/kafka:1.1@sha256:ba863ca7dc28563930584e37f93d57c2cbf3f46b1c1fa104fe8af7bcc0c31df4` already in use since https://github.com/Yolean/kubernetes-kafka/pull/172